### PR TITLE
Add root README and clarify backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# BLANX Social Media Platform
+
+BLANX is a full-stack social media project consisting of a Django backend and a React frontend. The backend exposes a REST API with real-time features while the frontend provides the client application. Docker and `docker-compose` are used for local development.
+
+## Architecture
+
+```
+./backend   - Django project with Celery and Channels
+./frontend  - React application using Redux and Tailwind
+./docker-compose.yml - Containers for PostgreSQL, Redis, Django, Daphne and Celery
+```
+
+### Backend
+- Django 4 with REST Framework
+- PostgreSQL for persistent storage
+- Redis for caching and Celery broker
+- Channels + Daphne for WebSocket support
+
+### Frontend
+- React with Redux Toolkit
+- TailwindCSS for styling
+- Communicates with the backend via REST and WebSockets
+
+## Setup
+
+### Backend
+1. `cd backend`
+2. Install dependencies (ideally inside a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `.env.example` to `.env` and adjust values as needed.
+4. Apply migrations and create a superuser:
+   ```bash
+   python manage.py migrate
+   python manage.py createsuperuser
+   ```
+5. Run the development server:
+   ```bash
+   python manage.py runserver
+   ```
+   - For WebSockets run `daphne -p 8001 config.asgi:application`.
+   - Start background workers using Celery:
+     ```bash
+     celery -A config worker -l info
+     celery -A config beat -l info
+     ```
+
+### Frontend
+1. `cd frontend`
+2. Install packages:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+
+## Docker Usage
+1. Ensure a `.env` file exists at the repository root (see `.env.example`).
+2. Build and start all services:
+   ```bash
+   docker-compose up --build
+   ```
+   - Django API available at `http://localhost:8000`
+   - ASGI/Daphne at `http://localhost:8001`
+3. Stop the stack with `docker-compose down`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,38 +9,48 @@
 
 ## Setup
 
-1. Install dependencies:
+1. (Optional) create and activate a virtual environment:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
 
-2. Set up PostgreSQL and Redis (see docker-compose.yml for example).
+3. Set up PostgreSQL and Redis (see docker-compose.yml for example).
 
-3. Set environment variables (or use .env):
+4. Copy `.env.example` to `.env` and set the following variables or export them in your shell:
    - `DJANGO_SECRET_KEY`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT`, `REDIS_URL`, etc.
 
-4. Run migrations:
+5. Run migrations:
    ```bash
    python manage.py makemigrations
    python manage.py migrate
    ```
 
-5. Create superuser:
+6. Create superuser:
    ```bash
    python manage.py createsuperuser
    ```
 
-6. Run development server:
+7. Run development server:
    ```bash
    python manage.py runserver
    ```
 
-7. Start Celery worker:
+8. Start Celery worker:
    ```bash
    celery -A config worker -l info
    ```
+9. Start Celery beat scheduler:
+   ```bash
+   celery -A config beat -l info
+   ```
 
-8. Start Channels/ASGI server (for WebSockets):
+10. Start Channels/ASGI server (for WebSockets):
    ```bash
    daphne -p 8001 config.asgi:application
-   ``` 
+   ```
+


### PR DESCRIPTION
## Summary
- add project README explaining architecture and Docker usage
- expand backend README with virtualenv, env file, and celery beat steps

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6885e80385f8832b9d3399a3049d97b1