### PR TITLE
Add basic tests and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# BLANX
+
+This repository contains both the Django backend and the React frontend for the social media platform.
+
+## Running Tests
+
+### Backend (Django)
+
+Use the provided test settings to run the Django test suite:
+
+```bash
+cd backend
+python manage.py test --settings=config.settings_test
+```
+
+### Frontend (React)
+
+React tests can be executed via the npm script at the project root:
+
+```bash
+npm test
+```
+
+This command proxies to the `frontend` package and runs `react-scripts test`.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,75 @@
-# BLANX
+# BLANX Social Media Platform
 
-This repository contains both the Django backend and the React frontend for the social media platform.
+BLANX is a full-stack social media project consisting of a Django backend and a React frontend. The backend exposes a REST API with real-time features while the frontend provides the client application. Docker and `docker-compose` are used for local development.
+
+## Architecture
+
+```
+./backend   - Django project with Celery and Channels
+./frontend  - React application using Redux and Tailwind
+./docker-compose.yml - Containers for PostgreSQL, Redis, Django, Daphne and Celery
+```
+
+### Backend
+- Django 4 with REST Framework
+- PostgreSQL for persistent storage
+- Redis for caching and Celery broker
+- Channels + Daphne for WebSocket support
+
+### Frontend
+- React with Redux Toolkit
+- TailwindCSS for styling
+- Communicates with the backend via REST and WebSockets
+
+## Setup
+
+### Backend
+1. `cd backend`
+2. Install dependencies (ideally inside a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `.env.example` to `.env` and adjust values as needed.
+4. Apply migrations and create a superuser:
+   ```bash
+   python manage.py migrate
+   python manage.py createsuperuser
+   ```
+5. Run the development server:
+   ```bash
+   python manage.py runserver
+   ```
+   - For WebSockets run `daphne -p 8001 config.asgi:application`.
+   - Start background workers using Celery:
+     ```bash
+     celery -A config worker -l info
+     celery -A config beat -l info
+     ```
+
+### Frontend
+1. `cd frontend`
+2. Install packages:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+
+## Docker Usage
+1. Ensure a `.env` file exists at the repository root (see `.env.example`).
+2. Build and start all services:
+   ```bash
+   docker-compose up --build
+   ```
+   - Django API available at `http://localhost:8000`
+   - ASGI/Daphne at `http://localhost:8001`
+3. Stop the stack with `docker-compose down`.
 
 ## Running Tests
 
 ### Backend (Django)
-
 Use the provided test settings to run the Django test suite:
 
 ```bash
@@ -14,7 +78,6 @@ python manage.py test --settings=config.settings_test
 ```
 
 ### Frontend (React)
-
 React tests can be executed via the npm script at the project root:
 
 ```bash
@@ -22,3 +85,4 @@ npm test
 ```
 
 This command proxies to the `frontend` package and runs `react-scripts test`.
+

--- a/backend/config/settings_test.py
+++ b/backend/config/settings_test.py
@@ -1,0 +1,17 @@
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'test_db.sqlite3',
+    }
+}
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    }
+}
+
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True

--- a/backend/posts/tests.py
+++ b/backend/posts/tests.py
@@ -1,0 +1,25 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+import tempfile
+
+User = get_user_model()
+
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
+class PostTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='tester', password='pass1234')
+
+    def test_create_post(self):
+        self.client.force_authenticate(user=self.user)
+        url = reverse('post-list-create')
+        image = SimpleUploadedFile('test.jpg', b'filecontent', content_type='image/jpeg')
+        data = {'caption': 'Hello', 'image': image}
+        response = self.client.post(url, data, format='multipart')
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(self.user.posts.count(), 1)
+        post = self.user.posts.first()
+        self.assertEqual(post.caption, 'Hello')
+

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,0 +1,20 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+class RegistrationTests(APITestCase):
+    def test_user_registration(self):
+        url = reverse('register')
+        data = {
+            'username': 'testuser',
+            'email': 'user@example.com',
+            'password': 'pass1234'
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(User.objects.filter(username='testuser').exists())
+        user = User.objects.get(username='testuser')
+        self.assertTrue(user.check_password('pass1234'))
+

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11"
+  },
+  "name": "blanx",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix frontend test"
   }
 }


### PR DESCRIPTION
## Summary
- add README with instructions on running tests
- configure root npm script to run frontend tests
- provide sqlite-based settings for backend tests
- add user registration and post creation tests

## Testing
- `python backend/manage.py test --settings=config.settings_test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e804a6a4832bb58e4301de9164e1