### PR TITLE
Fix ASGI router

### DIFF
--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -1,10 +1,17 @@
 import os
 from django.core.asgi import get_asgi_application
-from channels.routing import get_default_application
+from channels.routing import ProtocolTypeRouter
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 
+# Standard Django ASGI application
 django_asgi_app = get_asgi_application()
 
 import config.routing
-application = config.routing.application 
+
+# Route HTTP requests to Django and WebSocket connections to the
+# existing Channels URL router.
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": config.routing.application,
+})


### PR DESCRIPTION
## Summary
- route HTTP traffic in `asgi.py`

## Testing
- `python3 backend/manage.py runserver --noreload`
- `daphne backend.config.asgi:application`

------
https://chatgpt.com/codex/tasks/task_e_6885edf7fc60832bb1b6e0b55b31bdfe