### PR TITLE
Fix unlike post toggle

### DIFF
--- a/frontend/src/api/posts.js
+++ b/frontend/src/api/posts.js
@@ -5,5 +5,7 @@ export const fetchPosts = () => api.get('posts/');
 export const fetchUserPosts = (username) => api.get(`posts/user/${username}/`);
 export const createPost = (data) => api.post('posts/', data);
 export const likePost = (id) => api.post(`posts/${id}/like/`);
-export const unlikePost = (id) => api.delete(`posts/${id}/like/`);
+// The backend toggles like status via a POST request. Use the same
+// endpoint with POST for unliking to keep the client in sync.
+export const unlikePost = (id) => api.post(`posts/${id}/like/`);
 export const addComment = (postId, data) => api.post(`posts/${postId}/comments/`, data); 


### PR DESCRIPTION
## Summary
- update unlikePost API call to use POST instead of DELETE

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6885edff4cb8832b9565166c922e3b2a