### PR TITLE
Add React Native placeholder app

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Provider } from 'react-redux';
+import store from './src/store';
+
+import FeedScreen from './src/screens/FeedScreen';
+import LoginScreen from './src/screens/LoginScreen';
+import SignupScreen from './src/screens/SignupScreen';
+import ExploreScreen from './src/screens/ExploreScreen';
+import MessagesScreen from './src/screens/MessagesScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+import ReelsScreen from './src/screens/ReelsScreen';
+import AddStoryScreen from './src/screens/AddStoryScreen';
+import UploadScreen from './src/screens/UploadScreen';
+import NotificationsScreen from './src/screens/NotificationsScreen';
+import SearchScreen from './src/screens/SearchScreen';
+import StoryViewScreen from './src/screens/StoryViewScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Signup" component={SignupScreen} />
+          <Stack.Screen name="Feed" component={FeedScreen} />
+          <Stack.Screen name="Explore" component={ExploreScreen} />
+          <Stack.Screen name="Messages" component={MessagesScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen name="Settings" component={SettingsScreen} />
+          <Stack.Screen name="Reels" component={ReelsScreen} />
+          <Stack.Screen name="AddStory" component={AddStoryScreen} />
+          <Stack.Screen name="Upload" component={UploadScreen} />
+          <Stack.Screen name="Notifications" component={NotificationsScreen} />
+          <Stack.Screen name="Search" component={SearchScreen} />
+          <Stack.Screen name="StoryView" component={StoryViewScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "BLANX",
+    "slug": "blanx-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android", "web"],
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ]
+  }
+}

--- a/mobile/assets/icon.png
+++ b/mobile/assets/icon.png
@@ -1,0 +1,1 @@
+placeholder

--- a/mobile/assets/splash.png
+++ b/mobile/assets/splash.png
@@ -1,0 +1,1 @@
+placeholder

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "blanx-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~49.0.18",
+    "react": "18.2.0",
+    "react-native": "0.73.7",
+    "react-redux": "^9.2.0",
+    "redux": "^4.2.1",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.10.1",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/mobile/src/screens/AddStoryScreen.jsx
+++ b/mobile/src/screens/AddStoryScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const AddStoryScreen = () => (
+  <View style={styles.container}>
+    <Text>AddStory Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default AddStoryScreen;

--- a/mobile/src/screens/ExploreScreen.jsx
+++ b/mobile/src/screens/ExploreScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ExploreScreen = () => (
+  <View style={styles.container}>
+    <Text>Explore Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default ExploreScreen;

--- a/mobile/src/screens/FeedScreen.jsx
+++ b/mobile/src/screens/FeedScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const FeedScreen = () => (
+  <View style={styles.container}>
+    <Text>Feed Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default FeedScreen;

--- a/mobile/src/screens/LoginScreen.jsx
+++ b/mobile/src/screens/LoginScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const LoginScreen = () => (
+  <View style={styles.container}>
+    <Text>Login Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default LoginScreen;

--- a/mobile/src/screens/MessagesScreen.jsx
+++ b/mobile/src/screens/MessagesScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const MessagesScreen = () => (
+  <View style={styles.container}>
+    <Text>Messages Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default MessagesScreen;

--- a/mobile/src/screens/NotificationsScreen.jsx
+++ b/mobile/src/screens/NotificationsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const NotificationsScreen = () => (
+  <View style={styles.container}>
+    <Text>Notifications Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default NotificationsScreen;

--- a/mobile/src/screens/ProfileScreen.jsx
+++ b/mobile/src/screens/ProfileScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ProfileScreen = () => (
+  <View style={styles.container}>
+    <Text>Profile Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default ProfileScreen;

--- a/mobile/src/screens/ReelsScreen.jsx
+++ b/mobile/src/screens/ReelsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ReelsScreen = () => (
+  <View style={styles.container}>
+    <Text>Reels Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default ReelsScreen;

--- a/mobile/src/screens/SearchScreen.jsx
+++ b/mobile/src/screens/SearchScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SearchScreen = () => (
+  <View style={styles.container}>
+    <Text>Search Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SearchScreen;

--- a/mobile/src/screens/SettingsScreen.jsx
+++ b/mobile/src/screens/SettingsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SettingsScreen = () => (
+  <View style={styles.container}>
+    <Text>Settings Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SettingsScreen;

--- a/mobile/src/screens/SignupScreen.jsx
+++ b/mobile/src/screens/SignupScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SignupScreen = () => (
+  <View style={styles.container}>
+    <Text>Signup Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SignupScreen;

--- a/mobile/src/screens/StoryViewScreen.jsx
+++ b/mobile/src/screens/StoryViewScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const StoryViewScreen = () => (
+  <View style={styles.container}>
+    <Text>StoryView Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default StoryViewScreen;

--- a/mobile/src/screens/UploadScreen.jsx
+++ b/mobile/src/screens/UploadScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const UploadScreen = () => (
+  <View style={styles.container}>
+    <Text>Upload Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default UploadScreen;

--- a/mobile/src/store/index.js
+++ b/mobile/src/store/index.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './slices/authSlice';
+import postReducer from './slices/postSlice';
+
+export default configureStore({
+  reducer: {
+    auth: authReducer,
+    posts: postReducer,
+  },
+});

--- a/mobile/src/store/slices/authSlice.js
+++ b/mobile/src/store/slices/authSlice.js
@@ -1,0 +1,35 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  user: null,
+  token: null,
+  loading: false,
+  error: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser(state, action) {
+      state.user = action.payload;
+    },
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+    setLoading(state, action) {
+      state.loading = action.payload;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+      state.token = null;
+    },
+  },
+});
+
+export const { setUser, setToken, setLoading, setError, logout } = authSlice.actions;
+export const selectIsAuthenticated = (state) => !!state.auth.token;
+export default authSlice.reducer;

--- a/mobile/src/store/slices/postSlice.js
+++ b/mobile/src/store/slices/postSlice.js
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  posts: [],
+  loading: false,
+  error: null,
+};
+
+const postSlice = createSlice({
+  name: 'posts',
+  initialState,
+  reducers: {
+    setPosts(state, action) {
+      state.posts = action.payload;
+    },
+    setLoading(state, action) {
+      state.loading = action.payload;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+  },
+});
+
+export const { setPosts, setLoading, setError } = postSlice.actions;
+export default postSlice.reducer;


### PR DESCRIPTION
## Summary
- initialize a React Native project under `mobile`
- add Expo config and Redux store placeholders
- stub navigation and screen components to mirror web pages

## Testing
- `npm install` *(fails: E403 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688614adfe84832bb8f2fe42db978f2a