### PR TITLE
Add basic mobile feed and profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ BLANX is a full-stack social media project consisting of a Django backend and a 
 ```
 ./backend   - Django project with Celery and Channels
 ./frontend  - React application using Redux and Tailwind
+./mobile    - React Native app built with Expo
 ./docker-compose.yml - Containers for PostgreSQL, Redis, Django, Daphne and Celery
 ```
 
@@ -53,6 +54,17 @@ BLANX is a full-stack social media project consisting of a Django backend and a 
    npm install
    ```
 3. Start the development server:
+   ```bash
+   npm start
+   ```
+
+### Mobile (Expo)
+1. `cd mobile`
+2. Install packages:
+   ```bash
+   npm install
+   ```
+3. Start the Expo development server:
    ```bash
    npm start
    ```

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Provider } from 'react-redux';
+import store from './src/store';
+
+import FeedScreen from './src/screens/FeedScreen';
+import LoginScreen from './src/screens/LoginScreen';
+import SignupScreen from './src/screens/SignupScreen';
+import ExploreScreen from './src/screens/ExploreScreen';
+import MessagesScreen from './src/screens/MessagesScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+import ReelsScreen from './src/screens/ReelsScreen';
+import AddStoryScreen from './src/screens/AddStoryScreen';
+import UploadScreen from './src/screens/UploadScreen';
+import NotificationsScreen from './src/screens/NotificationsScreen';
+import SearchScreen from './src/screens/SearchScreen';
+import StoryViewScreen from './src/screens/StoryViewScreen';
+
+const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
+
+function MainTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name="Search" component={SearchScreen} />
+      <Tab.Screen name="Upload" component={UploadScreen} />
+      <Tab.Screen name="Notifications" component={NotificationsScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Signup" component={SignupScreen} />
+          <Stack.Screen name="Main" component={MainTabs} />
+          <Stack.Screen name="Explore" component={ExploreScreen} />
+          <Stack.Screen name="Messages" component={MessagesScreen} />
+          <Stack.Screen name="Settings" component={SettingsScreen} />
+          <Stack.Screen name="Reels" component={ReelsScreen} />
+          <Stack.Screen name="AddStory" component={AddStoryScreen} />
+          <Stack.Screen name="StoryView" component={StoryViewScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "BLANX",
+    "slug": "blanx-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android", "web"],
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ]
+  }
+}

--- a/mobile/assets/icon.png
+++ b/mobile/assets/icon.png
@@ -1,0 +1,1 @@
+placeholder

--- a/mobile/assets/splash.png
+++ b/mobile/assets/splash.png
@@ -1,0 +1,1 @@
+placeholder

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "blanx-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~49.0.18",
+    "react": "18.2.0",
+    "react-native": "0.73.7",
+    "react-redux": "^9.2.0",
+    "redux": "^4.2.1",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.10.1",
+    "@react-navigation/bottom-tabs": "^6.5.8",
+    "axios": "^1.5.0",
+    "@react-native-async-storage/async-storage": "^1.22.0",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/mobile/src/api/auth.js
+++ b/mobile/src/api/auth.js
@@ -1,0 +1,10 @@
+import api from './axios';
+
+export const login = (data) => api.post('auth/login/', data);
+export const signup = (data) => api.post('auth/register/', data);
+export const getCurrentUser = () => api.get('auth/me/');
+export const getProfile = (username) => api.get(`auth/profile/${username}/`);
+export const updateProfile = (username, data) => api.patch(`auth/profile/${username}/`, data);
+export const followUser = (id) => api.post(`auth/follow/${id}/`);
+export const unfollowUser = (id) => api.delete(`auth/follow/${id}/`);
+export const fetchSuggestedUsers = () => api.get('auth/suggested/');

--- a/mobile/src/api/axios.js
+++ b/mobile/src/api/axios.js
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:8000/api/';
+
+const api = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+api.interceptors.request.use(async (config) => {
+  const token = await AsyncStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response && error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const refresh = await AsyncStorage.getItem('refresh');
+      if (refresh) {
+        try {
+          const res = await axios.post(`${API_BASE_URL}auth/token/refresh/`, { refresh });
+          const newToken = res.data.access;
+          await AsyncStorage.setItem('token', newToken);
+          originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+          return api(originalRequest);
+        } catch (refreshError) {
+          await AsyncStorage.multiRemove(['token', 'refresh']);
+        }
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/mobile/src/api/dm.js
+++ b/mobile/src/api/dm.js
@@ -1,0 +1,6 @@
+import api from './axios';
+
+export const getConversations = () => api.get('dm/conversations/');
+export const createConversation = (userId) => api.post('dm/conversations/create/', { user_id: userId });
+export const getMessages = (conversationId) => api.get(`dm/conversations/${conversationId}/messages/`);
+export const sendMessage = (conversationId, content) => api.post(`dm/conversations/${conversationId}/messages/`, { content });

--- a/mobile/src/api/posts.js
+++ b/mobile/src/api/posts.js
@@ -1,0 +1,10 @@
+import api from './axios';
+
+export const fetchFeed = () => api.get('posts/feed/');
+export const fetchPosts = () => api.get('posts/');
+export const fetchUserPosts = (username) => api.get(`posts/user/${username}/`);
+export const createPost = (data) => api.post('posts/', data);
+export const likePost = (id) => api.post(`posts/${id}/like/`);
+export const unlikePost = (id) => api.post(`posts/${id}/like/`);
+export const addComment = (postId, data) => api.post(`posts/${postId}/comments/`, data);
+export const fetchLikedPosts = () => api.get('posts/liked/');

--- a/mobile/src/api/socket.js
+++ b/mobile/src/api/socket.js
@@ -1,0 +1,10 @@
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = process.env.EXPO_PUBLIC_SOCKET_URL || 'ws://localhost:8001';
+
+const socket = io(SOCKET_URL, {
+  autoConnect: false,
+  transports: ['websocket'],
+});
+
+export default socket;

--- a/mobile/src/api/stories.js
+++ b/mobile/src/api/stories.js
@@ -1,0 +1,9 @@
+import api from './axios';
+
+export const fetchStories = () => api.get('stories/');
+export const uploadStory = (data) => api.post('stories/', data, { headers: { 'Content-Type': 'multipart/form-data' } });
+export const deleteStory = (id) => api.delete(`stories/${id}/`);
+export const markStoryAsViewed = (id) => api.post(`stories/${id}/view/`);
+export const fetchStoryViewers = (id) => api.get(`stories/${id}/viewers/`);
+export const reactToStory = (id, emoji) => api.post(`stories/${id}/reactions/`, { emoji });
+export const commentOnStory = (id, content) => api.post(`stories/${id}/comments/`, { content });

--- a/mobile/src/components/PostItem.jsx
+++ b/mobile/src/components/PostItem.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+
+const PostItem = ({ user, image, caption }) => (
+  <View style={styles.card}>
+    <View style={styles.header}>
+      <Text style={styles.username}>{user?.username || 'Unknown'}</Text>
+    </View>
+    {image ? (
+      <Image source={{ uri: image }} style={styles.image} />
+    ) : null}
+    {caption ? <Text style={styles.caption}>{caption}</Text> : null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: '#fff', marginBottom: 16, padding: 8 },
+  header: { marginBottom: 8 },
+  username: { fontWeight: 'bold' },
+  image: { width: '100%', height: 200, marginBottom: 8 },
+  caption: { color: '#333' },
+});
+
+export default PostItem;

--- a/mobile/src/components/PostList.jsx
+++ b/mobile/src/components/PostList.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { FlatList } from 'react-native';
+import PostItem from './PostItem';
+
+const PostList = ({ posts }) => (
+  <FlatList
+    data={posts}
+    keyExtractor={(item) => String(item.id)}
+    renderItem={({ item }) => <PostItem {...item} />}
+  />
+);
+
+export default PostList;

--- a/mobile/src/screens/AddStoryScreen.jsx
+++ b/mobile/src/screens/AddStoryScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const AddStoryScreen = () => (
+  <View style={styles.container}>
+    <Text>AddStory Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default AddStoryScreen;

--- a/mobile/src/screens/ExploreScreen.jsx
+++ b/mobile/src/screens/ExploreScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ExploreScreen = () => (
+  <View style={styles.container}>
+    <Text>Explore Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default ExploreScreen;

--- a/mobile/src/screens/FeedScreen.jsx
+++ b/mobile/src/screens/FeedScreen.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { setPosts, setLoading, setError } from '../store/slices/postSlice';
+import { fetchFeed } from '../api/posts';
+import PostList from '../components/PostList';
+
+const FeedScreen = () => {
+  const dispatch = useDispatch();
+  const { posts, loading, error } = useSelector((state) => state.posts);
+
+  useEffect(() => {
+    const load = async () => {
+      dispatch(setLoading(true));
+      dispatch(setError(null));
+      try {
+        const res = await fetchFeed();
+        dispatch(setPosts(res.data));
+      } catch {
+        dispatch(setError('Failed to load feed.'));
+      } finally {
+        dispatch(setLoading(false));
+      }
+    };
+    load();
+  }, [dispatch]);
+
+  return (
+    <View style={styles.container}>
+      {loading ? (
+        <Text>Loading...</Text>
+      ) : error ? (
+        <Text>{error}</Text>
+      ) : (
+        <PostList posts={posts} />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 }
+});
+
+export default FeedScreen;

--- a/mobile/src/screens/LoginScreen.jsx
+++ b/mobile/src/screens/LoginScreen.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput, Button } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { setUser, setToken, setLoading, setError } from '../store/slices/authSlice';
+import { login, getCurrentUser } from '../api/auth';
+
+const LoginScreen = ({ navigation }) => {
+  const dispatch = useDispatch();
+  const { loading, error } = useSelector((state) => state.auth);
+  const [form, setForm] = useState({ login: '', password: '' });
+
+  const handleChange = (name, value) => {
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async () => {
+    dispatch(setLoading(true));
+    try {
+      const res = await login(form);
+      dispatch(setToken(res.data.access));
+      await AsyncStorage.setItem('token', res.data.access);
+      if (res.data.refresh) {
+        await AsyncStorage.setItem('refresh', res.data.refresh);
+      }
+
+      try {
+        const userRes = await getCurrentUser();
+        dispatch(setUser(userRes.data));
+      } catch (profileErr) {
+        console.error('Failed to fetch user profile:', profileErr);
+      }
+
+      navigation.navigate('Feed');
+    } catch (err) {
+      dispatch(setError(err.response?.data?.detail || 'Login failed'));
+    } finally {
+      dispatch(setLoading(false));
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>BLANX Login</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Username or Email"
+        value={form.login}
+        onChangeText={(text) => handleChange('login', text)}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        secureTextEntry
+        value={form.password}
+        onChangeText={(text) => handleChange('password', text)}
+      />
+      <Button title={loading ? 'Logging in...' : 'Login'} onPress={handleSubmit} disabled={loading} />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  input: {
+    width: '100%',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginBottom: 12,
+    padding: 8,
+    borderRadius: 4,
+  },
+  error: {
+    color: 'red',
+    marginTop: 8,
+  },
+});
+
+export default LoginScreen;

--- a/mobile/src/screens/MessagesScreen.jsx
+++ b/mobile/src/screens/MessagesScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const MessagesScreen = () => (
+  <View style={styles.container}>
+    <Text>Messages Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default MessagesScreen;

--- a/mobile/src/screens/NotificationsScreen.jsx
+++ b/mobile/src/screens/NotificationsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const NotificationsScreen = () => (
+  <View style={styles.container}>
+    <Text>Notifications Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default NotificationsScreen;

--- a/mobile/src/screens/ProfileScreen.jsx
+++ b/mobile/src/screens/ProfileScreen.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, StyleSheet, FlatList } from 'react-native';
+import { useSelector } from 'react-redux';
+import { getProfile } from '../api/auth';
+import { fetchUserPosts } from '../api/posts';
+
+const ProfileScreen = () => {
+  const currentUser = useSelector((state) => state.auth.user);
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!currentUser) return;
+      try {
+        const res = await getProfile(currentUser.username);
+        setProfile(res.data);
+        const postRes = await fetchUserPosts(currentUser.username);
+        setPosts(postRes.data);
+      } catch {}
+    };
+    load();
+  }, [currentUser]);
+
+  if (!currentUser) {
+    return (
+      <View style={styles.centered}>
+        <Text>Please log in.</Text>
+      </View>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <View style={styles.centered}>
+        <Text>Loading profile...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        {profile.avatar ? (
+          <Image source={{ uri: profile.avatar }} style={styles.avatar} />
+        ) : (
+          <View style={[styles.avatar, styles.placeholder]} />
+        )}
+        <Text style={styles.username}>{profile.username}</Text>
+      </View>
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => String(item.id)}
+        numColumns={3}
+        renderItem={({ item }) => (
+          <Image source={{ uri: item.image }} style={styles.postImage} />
+        )}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+  },
+  avatar: { width: 60, height: 60, borderRadius: 30, marginRight: 16 },
+  placeholder: { backgroundColor: '#ccc' },
+  username: { fontSize: 20, fontWeight: 'bold' },
+  postImage: { width: '33%', aspectRatio: 1 },
+});
+
+export default ProfileScreen;

--- a/mobile/src/screens/ReelsScreen.jsx
+++ b/mobile/src/screens/ReelsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ReelsScreen = () => (
+  <View style={styles.container}>
+    <Text>Reels Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default ReelsScreen;

--- a/mobile/src/screens/SearchScreen.jsx
+++ b/mobile/src/screens/SearchScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SearchScreen = () => (
+  <View style={styles.container}>
+    <Text>Search Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SearchScreen;

--- a/mobile/src/screens/SettingsScreen.jsx
+++ b/mobile/src/screens/SettingsScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SettingsScreen = () => (
+  <View style={styles.container}>
+    <Text>Settings Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SettingsScreen;

--- a/mobile/src/screens/SignupScreen.jsx
+++ b/mobile/src/screens/SignupScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SignupScreen = () => (
+  <View style={styles.container}>
+    <Text>Signup Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default SignupScreen;

--- a/mobile/src/screens/StoryViewScreen.jsx
+++ b/mobile/src/screens/StoryViewScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const StoryViewScreen = () => (
+  <View style={styles.container}>
+    <Text>StoryView Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default StoryViewScreen;

--- a/mobile/src/screens/UploadScreen.jsx
+++ b/mobile/src/screens/UploadScreen.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const UploadScreen = () => (
+  <View style={styles.container}>
+    <Text>Upload Screen - TODO</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});
+
+export default UploadScreen;

--- a/mobile/src/store/index.js
+++ b/mobile/src/store/index.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './slices/authSlice';
+import postReducer from './slices/postSlice';
+
+export default configureStore({
+  reducer: {
+    auth: authReducer,
+    posts: postReducer,
+  },
+});

--- a/mobile/src/store/slices/authSlice.js
+++ b/mobile/src/store/slices/authSlice.js
@@ -1,0 +1,35 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  user: null,
+  token: null,
+  loading: false,
+  error: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser(state, action) {
+      state.user = action.payload;
+    },
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+    setLoading(state, action) {
+      state.loading = action.payload;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+      state.token = null;
+    },
+  },
+});
+
+export const { setUser, setToken, setLoading, setError, logout } = authSlice.actions;
+export const selectIsAuthenticated = (state) => !!state.auth.token;
+export default authSlice.reducer;

--- a/mobile/src/store/slices/postSlice.js
+++ b/mobile/src/store/slices/postSlice.js
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  posts: [],
+  loading: false,
+  error: null,
+};
+
+const postSlice = createSlice({
+  name: 'posts',
+  initialState,
+  reducers: {
+    setPosts(state, action) {
+      state.posts = action.payload;
+    },
+    setLoading(state, action) {
+      state.loading = action.payload;
+    },
+    setError(state, action) {
+      state.error = action.payload;
+    },
+  },
+});
+
+export const { setPosts, setLoading, setError } = postSlice.actions;
+export default postSlice.reducer;


### PR DESCRIPTION
## Summary
- introduce bottom tab navigation in the mobile app
- add a PostList component that fetches feed posts
- implement ProfileScreen to load user profile and posts
- update mobile dependencies for bottom tab navigation

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688614adfe84832bb8f2fe42db978f2a